### PR TITLE
fix: allow read requests to other users data

### DIFF
--- a/src/secretvaults/dto/users.py
+++ b/src/secretvaults/dto/users.py
@@ -53,6 +53,7 @@ class ReadDataRequestParams(BaseModel):
 
     collection: Uuid
     document: Uuid
+    subject: Optional[Uuid] = None
 
 
 class OwnedDataDto(BaseModel, extra=Extra.allow):

--- a/src/secretvaults/user.py
+++ b/src/secretvaults/user.py
@@ -203,6 +203,7 @@ class SecretVaultUserClient(SecretVaultBaseClient[NilDbUserClient]):
                 self._mint_invocation(
                     command=NucCmd.NIL_DB_USERS_READ,
                     audience=client.id,
+                    subject=Did.parse(params.subject) if params.subject else None,
                 ),
                 params,
             ),
@@ -386,7 +387,7 @@ class SecretVaultUserClient(SecretVaultBaseClient[NilDbUserClient]):
             if hasattr(node, "close") and callable(getattr(node, "close")):
                 await node.close()
 
-    def _mint_invocation(self, command: NucCmd, audience: Did) -> str:
+    def _mint_invocation(self, command: NucCmd, audience: Did, subject: Optional[Did] = None) -> str:
         """Mints an invocation token for user operations.
 
         Args:
@@ -402,7 +403,7 @@ class SecretVaultUserClient(SecretVaultBaseClient[NilDbUserClient]):
         # Build the token with all required parameters
         token = (
             builder.command(Command(command.value.split(".")))
-            .subject(self.id)  # User's DID as subject
+            .subject(subject if subject else self.id)  # User's DID as subject
             .audience(audience)  # Target node's DID
             .expires_at(datetime.fromtimestamp(into_seconds_from_now(60)))
             .build(self.keypair.private_key())


### PR DESCRIPTION
When you try to read from another user's data stored in whatever owned collection, the minted token has `self.id` as the default subject. This makes it so that a user cannot read from other user collections or data. 

In order to address it, I add a new parameter `subject` to ReadDataRequest which is `None` by default. If specified, it replaces `self.id`. 

Note: Probably ignoring other cross-behaviours with other components, feel free to point me to what needs modifications.