### PR TITLE
feat: dependency and read the docs updates

### DIFF
--- a/.github/workflows/build-publish-sign-release.yml
+++ b/.github/workflows/build-publish-sign-release.yml
@@ -14,9 +14,9 @@ jobs:
       - call-workflow-lint-test-cover-docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
           architecture: x64
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the package distributions.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-package-distributions
           path: dist/
@@ -58,12 +58,12 @@ jobs:
       id-token: write # For Sigstore.
     steps:
       - name: Download all the package distributions.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: python-package-distributions
           path: dist/
       - name: Sign the package distributions with Sigstore.
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/lint-test-cover-docs.yml
+++ b/.github/workflows/lint-test-cover-docs.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.pylintrc
+++ b/.pylintrc
@@ -59,10 +59,11 @@ ignore-paths=
 # Emacs file locks
 ignore-patterns=^\.#
 
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
 ignored-modules=
 
 # Python code to execute, usually for sys.path manipulation such as
@@ -86,9 +87,13 @@ load-plugins=
 # Pickle collected data for later comparisons.
 persistent=yes
 
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.12
 
 # Discover python modules and packages in the file system subtree.
 recursive=no
@@ -302,6 +307,9 @@ max-locals=30
 # Maximum number of parents for a class (see R0901).
 max-parents=7
 
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
@@ -429,14 +437,14 @@ disable=raw-checker-failed,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        unnecessary-lambda-assignment,
-        redundant-unittest-assert
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=
 
 
 [METHOD_ARGS]
@@ -468,6 +476,11 @@ max-nested-blocks=5
 # printed.
 never-returning-functions=sys.exit,argparse.parse_error
 
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
 
 [REPORTS]
 
@@ -482,9 +495,10 @@ evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor 
 # used to format the message information. See doc for all details.
 msg-template=
 
-# Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
-# mypackage.mymodule.MyReporterClass.
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
 #output-format=
 
 # Tells whether to display a full report or only the messages.
@@ -518,7 +532,7 @@ min-similarity-lines=4
 max-spelling-suggestions=4
 
 # Spelling dictionary name. No available dictionaries : You need to install
-# both the python package and the system dependency for enchant to work..
+# both the python package and the system dependency for enchant to work.
 spelling-dict=
 
 # List of comma separated words that should be considered directives if they
@@ -586,7 +600,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
 # of finding the hint is based on edit distance.
 missing-member-hint=yes
 
-# The minimum edit distance a name should have in order to be considered a
+# The maximum edit distance a name should have in order to be considered a
 # similar match for a missing member name.
 missing-member-hint-distance=1
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,14 +6,10 @@ sphinx:
 formats:
   - pdf
 
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
 build:
   os: 'ubuntu-22.04'
   tools:
-    python: '3.10'
+    python: '3.12'
+  jobs:
+    install:
+      - python -m pip install --no-cache-dir --use-pep517 .[docs]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,4 @@ python:
 build:
   os: 'ubuntu-22.04'
   tools:
-    python: '3.12'
+    python: '3.10'

--- a/README.rst
+++ b/README.rst
@@ -1,41 +1,34 @@
+============
 secretvaults
-=============
+============
 
 SDK for interacting with Nillion's `Private Storage <https://docs.nillion.com/build/private-storage/overview>`__ solutions.
 
-|pypi| |actions|
+|pypi| |readthedocs| |actions| |coveralls|
 
-.. |pypi| image:: https://badge.fury.io/py/secretvaults.svg
+.. |pypi| image:: https://badge.fury.io/py/secretvaults.svg#
    :target: https://badge.fury.io/py/secretvaults
    :alt: PyPI version and link.
 
-.. .. |readthedocs| image:: https://readthedocs.org/projects/secretvaults/badge/?version=latest
-..    :target: https://secretvaults.readthedocs.io/en/latest/?badge=latest
-..    :alt: Read the Docs documentation status.
+.. |readthedocs| image:: https://readthedocs.org/projects/secretvaults/badge/?version=latest
+   :target: https://secretvaults.readthedocs.io/en/latest/?badge=latest
+   :alt: Read the Docs documentation status.
 
-.. |actions| image:: https://github.com/nillionnetwork/nillion-sv-wrappers-py/workflows/lint-test-cover-docs/badge.svg
-   :target: https://github.com/nillionnetwork/nillion-sv-wrappers-py/actions/workflows/lint-test-cover-docs.yml
+.. |actions| image:: https://github.com/nillionnetwork/secretvaults-py/workflows/lint-test-cover-docs/badge.svg#
+   :target: https://github.com/nillionnetwork/secretvaults-py/actions/workflows/lint-test-cover-docs.yml
    :alt: GitHub Actions status.
 
-.. .. |coveralls| image:: https://coveralls.io/repos/github/NillionNetwork/secretvaults-py/badge.svg?branch=main
-..    :target: https://coveralls.io/github/NillionNetwork/secretvaults-py?branch=main
-..    :alt: Coveralls test coverage summary.
-
-Description and Purpose
-------------------------
-
-Provides functions to simplify usage of Nillion's Private Storage.
-
+.. |coveralls| image:: https://coveralls.io/repos/github/NillionNetwork/secretvaults-py/badge.svg?branch=main
+   :target: https://coveralls.io/github/NillionNetwork/secretvaults-py?branch=main
+   :alt: Coveralls test coverage summary.
 
 Installation and Usage
------------------------
-
+----------------------
 You can install the package using pip:
 
 .. code-block:: bash
 
     pip install secretvaults
-
 
 The library can be imported in the usual ways:
 
@@ -44,17 +37,13 @@ The library can be imported in the usual ways:
     import secretvaults
     from secretvaults import *
 
-
-
-Examples and Documentation
--------------------------------
-
+Examples and Usage Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Please see the `examples <https://github.com/NillionNetwork/secretvaults-py/tree/main/examples>`__ directory for examples and documentation.
 
 
 Development
 -----------
-
 All installation and development dependencies are fully specified in ``pyproject.toml``. The ``project.optional-dependencies`` object is used to `specify optional requirements <https://peps.python.org/pep-0621>`__ for various development tasks. This makes it possible to specify additional options (such as ``docs``, ``lint``, and so on) when performing installation using `pip <https://pypi.org/project/pip>`__:
 
 .. code-block:: bash
@@ -62,19 +51,17 @@ All installation and development dependencies are fully specified in ``pyproject
     python -m pip install ".[docs,lint]"
 
 Documentation
--------------
-
+^^^^^^^^^^^^^
 The documentation can be generated automatically from the source files using `Sphinx <https://www.sphinx-doc.org>`__:
 
 .. code-block:: bash
 
     python -m pip install ".[docs]"
     cd docs
-    sphinx-apidoc -f -E --templatedir=_templates -o _source .. && make html
+    sphinx-apidoc -f -E --templatedir=_templates -o _source ../src && make html
 
 Testing and Conventions
-------------------------
-
+^^^^^^^^^^^^^^^^^^^^^^^
 All unit tests are executed and their coverage is measured when using `pytest <https://docs.pytest.org>`__ (see the ``pyproject.toml`` file for configuration details):
 
 .. code-block:: bash
@@ -90,17 +77,15 @@ Style conventions are enforced using `Pylint <https://pylint.readthedocs.io>`__:
     python -m pylint src/secretvaults
 
 Contributions
--------------
-
-To contribute to the source code, open an issue or submit a pull request on the `GitHub page <https://github.com/nillionnetwork/secretvaults-py>`__ for this library.
+^^^^^^^^^^^^^
+In order to contribute to the source code, open an issue or submit a pull request on the `GitHub page <https://github.com/nillionnetwork/secretvaults-py>`__ for this library.
 
 Versioning
-----------
-
-The version number format for this library and the changes to the library associated with version number increments conform to `Semantic Versioning 2.0.0 <https://semver.org/#semantic-versioning-200>`__.
+^^^^^^^^^^
+The version number format for this library and the changes to the library associated with version number increments conform with `Semantic Versioning 2.0.0 <https://semver.org/#semantic-versioning-200>`__.
 
 Publishing
-----------
-
+^^^^^^^^^^
 This library can be published as a `package on PyPI <https://pypi.org/project/secretvaults>`__ via the GitHub Actions workflow found in ``.github/workflows/build-publish-sign-release.yml`` that follows the `recommendations found in the Python Packaging User Guide <https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/>`__.
 
+Ensure that any links in this README document to the Read the Docs documentation of this package (or its dependencies) have appropriate version numbers. Also ensure that the Read the Docs project for this library has an `automation rule <https://docs.readthedocs.io/en/stable/automation-rules.html>`__ that activates and sets as the default all tagged versions.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,4 +18,8 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	rm _source/modules.rst
+	rm _source/secretvaults.rst
+	rm _source/secretvaults.common.rst
+	rm _source/secretvaults.dto.rst
+	rm _source/secretvaults.nildb.rst
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_source/secretvaults.common.paths.rst
+++ b/docs/_source/secretvaults.common.paths.rst
@@ -5,3 +5,7 @@ common.paths
    :members:
    :undoc-members:
    :show-inheritance:
+
+.. autoclass:: secretvaults.common.paths.NilDbEndpointClass.v1
+   :members:
+   :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -117,7 +117,6 @@ html_theme = 'sphinx_rtd_theme'
 
 # Theme options for Read the Docs.
 html_theme_options = {
-    'display_version': True,
     'collapse_navigation': True,
     'navigation_depth': 1,
     'titles_only': True

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -13,6 +13,10 @@ set BUILDDIR=_build
 if "%1" == "" goto help
 
 del _source\modules.rst
+del _source\secretvaults.rst
+del _source\secretvaults.common.rst
+del _source\secretvaults.dto.rst
+del _source\secretvaults.nildb.rst
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 description = "SDK for interacting with Nillion's Private Storage solutions."
 readme = "README.rst"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.8.0",
     "blindfold>=0.1.0rc0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp>=3.8.0",
-    "blindfold>=0.1.0rc0",
+    "blindfold~=0.1.0",
     "nuc>=0.1.0",
     "pydantic>=2.0.0",
     "structlog>=23.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "secretvaults"
-version = "0.2.1"
+version = "0.3.0"
 description = "SDK for interacting with Nillion's Private Storage solutions."
 readme = "README.rst"
-license = {text = "MIT"}
-requires-python = ">=3.12"
+license = "MIT"
+requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.8.0",
     "blindfold>=0.1.0rc0",
@@ -17,16 +17,16 @@ dependencies = [
 [project.optional-dependencies]
 docs = [
     "toml~=0.10.2",
-    "sphinx~=5.0",
-    "sphinx-rtd-theme~=2.0.0"
+    "sphinx~=7.4",
+    "sphinx-rtd-theme~=3.0"
 ]
 test = [
-    "pytest~=8.2",
-    "pytest-cov~=5.0",
+    "pytest~=8.4",
+    "pytest-cov~=7.0",
     "pytest-asyncio~=0.25.3"
 ]
 lint = [
-    "pylint~=3.2.0",
+    "pylint~=3.3.0",
     "black>=23.0.0"
 ]
 coveralls = [
@@ -38,7 +38,9 @@ publish = [
 ]
 
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = [
+    "setuptools>=77.0"
+]
 build-backend = "setuptools.build_meta"
 
 [project.urls]

--- a/src/secretvaults/common/blindfold.py
+++ b/src/secretvaults/common/blindfold.py
@@ -38,7 +38,7 @@ class BlindfoldFactoryConfig:  # pylint: disable=too-few-public-methods
         seed: Optional[Union[bytes, str]] = None,
         use_cluster_key: Optional[bool] = None,
         threshold: Optional[int] = None,
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-positional-arguments
         # Validate configuration based on scenarios
         if key is not None:
             # Scenario 1: Use pre-existing key

--- a/src/secretvaults/common/paths.py
+++ b/src/secretvaults/common/paths.py
@@ -1,76 +1,76 @@
 """
 API endpoint paths for Nildb client, matching the TypeScript NilDbEndpoint structure.
 """
+# pylint: disable=invalid-name,disable=too-few-public-methods
 
-
-class NilDbEndpoint:  # pylint: disable=too-few-public-methods
+class NilDbEndpoint: 
     """Root of all API endpoint paths for the Nildb client, matching the TypeScript NilDbEndpoint structure."""
 
-    class v1:  # pylint: disable=invalid-name,too-few-public-methods
+    class v1:
         """Version 1 API endpoints."""
 
-        class builders:  # pylint: disable=invalid-name,too-few-public-methods
+        class builders:
             """Endpoints for builder operations."""
 
-            register = "/v1/builders/register"
-            me = "/v1/builders/me"
+            register = '/v1/builders/register'
+            me = '/v1/builders/me'
 
-        class data:  # pylint: disable=invalid-name,too-few-public-methods
+        class data:
             """Endpoints for data operations."""
 
-            root = "/v1/data"
-            find = "/v1/data/find"
-            update = "/v1/data/update"
-            delete = "/v1/data/delete"
-            flushById = "/v1/data/:id/flush"
-            tailById = "/v1/data/:id/tail"
-            createOwned = "/v1/data/owned"
-            createStandard = "/v1/data/standard"
+            root = '/v1/data'
+            find = '/v1/data/find'
+            update = '/v1/data/update'
+            delete = '/v1/data/delete'
+            flushById = '/v1/data/:id/flush'
+            tailById = '/v1/data/:id/tail'
+            createOwned = '/v1/data/owned'
+            createStandard = '/v1/data/standard'
 
-        class queries:  # pylint: disable=invalid-name,too-few-public-methods
+        class queries:
             """Endpoints for query operations."""
 
-            root = "/v1/queries"
-            byId = "/v1/queries/:id"
-            run = "/v1/queries/run"
-            runById = "/v1/queries/run/:id"
+            root = '/v1/queries'
+            byId = '/v1/queries/:id'
+            run = '/v1/queries/run'
+            runById = '/v1/queries/run/:id'
 
-        class collections:  # pylint: disable=invalid-name,too-few-public-methods
+        class collections:
             """Endpoints for collection operations."""
 
-            root = "/v1/collections"
-            byId = "/v1/collections/:id"
-            indexesById = "/v1/collections/:id/indexes"
-            indexesByNameById = "/v1/collections/:id/indexes/:name"
+            root = '/v1/collections'
+            byId = '/v1/collections/:id'
+            indexesById = '/v1/collections/:id/indexes'
+            indexesByNameById = '/v1/collections/:id/indexes/:name'
 
-        class system:  # pylint: disable=invalid-name,too-few-public-methods
+        class system:
             """Endpoints for system operations and health checks."""
 
-            about = "/about"
-            health = "/health"
-            metrics = "/metrics"
-            openApiJson = "/openapi.json"
-            maintenanceStart = "/v1/system/maintenance/start"
-            maintenanceStop = "/v1/system/maintenance/stop"
-            logLevel = "/v1/system/log-level"
+            about = '/about'
+            health = '/health'
+            metrics = '/metrics'
+            openApiJson = '/openapi.json'
+            maintenanceStart = '/v1/system/maintenance/start'
+            maintenanceStop = '/v1/system/maintenance/stop'
+            logLevel = '/v1/system/log-level'
 
-        class users:  # pylint: disable=invalid-name,too-few-public-methods
+        class users:
             """Endpoints for user operations."""
 
-            me = "/v1/users/me"
+            me = '/v1/users/me'
 
-            class data:  # pylint: disable=invalid-name,too-few-public-methods
+            class data:
                 """Endpoints for user data operations."""
 
-                root = "/v1/users/data"
-                byId = "/v1/users/data/:collection/:document"
-                aclById = "/v1/users/data/:collection/:document/acl"
+                root = '/v1/users/data'
+                byId = '/v1/users/data/:collection/:document'
+                aclById = '/v1/users/data/:collection/:document/acl'
 
-                class acl:  # pylint: disable=invalid-name,too-few-public-methods
+                class acl:
                     """Endpoints for user data ACL operations."""
 
-                    grant = "/v1/users/data/acl/grant"
-                    revoke = "/v1/users/data/acl/revoke"
+                    grant = '/v1/users/data/acl/grant'
+                    revoke = '/v1/users/data/acl/revoke'
 
-
+NilDbEndpointClass = NilDbEndpoint
 NilDbEndpoint = NilDbEndpoint()


### PR DESCRIPTION
Bumps dependency version locks, GitHub Actions versions, and linting rules; adds Python 3.13 tests and [Read the Docs support](https://secretvaults.readthedocs.io/en/feat-dependency-and-read-the-docs-updates/_source/secretvaults.common.blindfold.html).

The support for Read the Docs may require repair shortly because it was fixed using the flag suggested below:
```
  | Requirements should be satisfied by a PEP 517 installer.
  | If you are using pip, you can try `pip install --use-pep517`.
  |  
  | By 2025-Oct-31, you need to update your project and remove deprecated calls
  | or your builds will no longer be supported.
```
Ultimately, the possibility of secp256k1 building in up-to-date environments will erode over time and we may need to fork our own version so we can publish our own updated wheel files for various platforms.